### PR TITLE
Use native crypto.randomUUID explicitly

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,8 +22,7 @@
     "sass": "^1.62.1",
     "tailwind-merge": "^1.12.0",
     "tailwindcss-animate": "^1.0.5",
-    "use-resize-observer": "^9.1.0",
-    "uuid": "^9.0.0"
+    "use-resize-observer": "^9.1.0"
   },
   "devDependencies": {
     "@types/react": "^18.0.28",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,3 @@
-import { v4 as uuidv4 } from "uuid";
-
 import React from "react";
 import {
   EIP6963AnnounceProviderEvent,
@@ -170,7 +168,7 @@ function App() {
 
   const addWindowProvider = () => {
     if (typeof window.ethereum !== "undefined") {
-      const uuid = windowProviderUUID || uuidv4().toString();
+      const uuid = windowProviderUUID || crypto.randomUUID();
       setWindowProviderUUID(uuid);
       window.dispatchEvent(
         new CustomEvent("eip6963:announceProvider", {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4295,11 +4295,6 @@ uuid@^8.3.2:
   resolved "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
 
-uuid@^9.0.0:
-  version "9.0.0"
-  resolved "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz"
-  integrity sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==
-
 valtio@1.10.5:
   version "1.10.5"
   resolved "https://registry.npmjs.org/valtio/-/valtio-1.10.5.tgz"


### PR DESCRIPTION
Browser support for native crypto is [very good](https://caniuse.com/mdn-api_crypto_randomuuid), and `uuid` uses this method anyway under the hood.

Even though this is just a demo app, I believe it's better to prescribe the usage of native (browser) crypto methods.