### PR TITLE
chore: removed rainbow

### DIFF
--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -8,10 +8,6 @@ export const supportedWallets = [
     url: "https://zerion.io",
   },
   {
-    name: "Rainbow",
-    url: "https://rainbow.me/extension",
-  },
-  {
     name: "Iron",
     url: "https://github.com/iron-wallet/iron",
   },


### PR DESCRIPTION
Removed Rainbow Wallet due to breaking compatibility issues