### PR TITLE
Add Milkomeda WSC to EIP6963 list

### DIFF
--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -91,4 +91,8 @@ export const supportedWallets = [
     name: "Fluvi",
     url: "https://fluviwallet.xyz/",
   },
+  {
+    name: "Milkomeda WSC Provider",
+    url: "https://milkomeda.com",
+  },    
 ];


### PR DESCRIPTION
Milkomeda WSC provider is a tool to allow connecting Cardano wallets to EVM smart contracts by wrapping it in a EIP-1193 / EIP-6963 compatible wrapper

The package for it is [on NPM](https://www.npmjs.com/package/milkomeda-wsc) and mentioned in [our docs](https://docs.milkomeda.com/cardano/wrapped-smart-contracts)