### PR TITLE
feat: add pockie wallet

### DIFF
--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -95,4 +95,8 @@ export const supportedWallets = [
     name: "Safeheron Wallet",
     url: "https://safeheron.com/",
   },
+  {
+    name: "Pockie Wallet",
+    url: "https://www.pockie.io",
+  },
 ];


### PR DESCRIPTION
Pockie Wallet already supports the EIP6963 protocol.
Chrome extension download at https://chromewebstore.google.com/detail/pockie-wallet/dmjmllblpcbmniokccdoaiahcdajdjof