### PR TITLE
Add Okto Wallet to Supported Wallets

### DIFF
--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -95,4 +95,8 @@ export const supportedWallets = [
     name: "Safeheron Wallet",
     url: "https://safeheron.com/",
   },
+  {
+    name: "Okto Wallet",
+    url: "https://okto.tech/",
+  },
 ];


### PR DESCRIPTION
Hello WalletConnect team,

[Okto Wallet](https://okto.tech/) has recently added support for ERC-6963 to its inAppBrowser for dapps. 

This PR adds Okto Wallet to the list of supported ERC-6963 wallets within this repository. 

Thanks