### PR TITLE
Update constants.ts

### DIFF
--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -111,4 +111,8 @@ export const supportedWallets = [
     name: "Loopring",
     url: "https://www.loopring.io",
   },
+  {
+    name: "Keplr",
+    url: "https://www.keplr.app/",
+  },
 ];


### PR DESCRIPTION
Keplr now supports EVM chains and EIP 6963. Added Keplr at the very end of the list. 